### PR TITLE
Fix toaster component styles

### DIFF
--- a/src/components/providers/toaster.tsx
+++ b/src/components/providers/toaster.tsx
@@ -10,14 +10,11 @@ export const ToasterComponent = () => {
       position="bottom-right"
       theme={theme === "dark" ? "dark" : "light"}
       toastOptions={{
-        style: {
-          background: theme === "dark" ? "#171717" : "#f3f4f6",
-          color: theme === "dark" ? "#f5f5f5" : "#1f2937",
-          borderColor: theme === "dark" ? "#262626" : "#e5e7eb",
-        },
         classNames: {
-          toast: "font-sans",
+          toast:
+            "font-sans dark:bg-[#171717] bg-[#f3f4f6] text-[#1f2937] dark:text-[#f5f5f5] dark:border-[#262626]",
           description: "font-mono",
+          closeButton: "dark:bg-[#262626] dark:hover:bg-[#464646]",
         },
       }}
     />


### PR DESCRIPTION
When you select the 'System' theme, that is, the system theme, the Toast did not understand the colors it should modify (77da8c4c6477581e983dedb10d7d5d06b84ed3b9) and displayed in the light theme, even if your system is in dark mode. This is solved by modifying the Toast design with TailwindCSS 

> [!NOTE]
> The error is practically visible when you have dark mode enabled on your system and choose the 'system' theme.


> Currently it looks like this `System theme when you have dark mode enabled`
![msedge_PM94Ajzwop](https://github.com/pheralb/slug/assets/62324080/14c75bd8-84e7-4e53-8092-3b7f12e4ba8d)

> As it appears in the light theme, `there is no error in this theme`
![msedge_OoULFGF3sB](https://github.com/pheralb/slug/assets/62324080/921b6dd7-93f5-424d-9dcb-d9005ccce0e0)

> Now you can see how it's fixed in both themes.
![msedge_BZzhvQoPv8](https://github.com/pheralb/slug/assets/62324080/fc8d6f36-faa3-4ef0-96ab-daed34873ce6)
![msedge_sC8AuEVhqe](https://github.com/pheralb/slug/assets/62324080/8ca6c7df-8b7c-4c9f-bc46-530484d87a53)