### PR TITLE
Fixed link and container layout for improved handling of long words.

### DIFF
--- a/src/components/links/card-link.tsx
+++ b/src/components/links/card-link.tsx
@@ -46,7 +46,7 @@ const CardLink = ({ linkInfo, linkTags, tagsInfo }: CardLinkProps) => {
       <div className="mb-1 flex w-full items-center justify-between space-x-2">
         <ExternalLink
           href={`/${linkInfo.slug}`}
-          className="flex items-center space-x-[1px] font-medium transition-opacity duration-75 hover:opacity-80"
+          className="block  space-x-[1px] overflow-hidden truncate font-medium transition-opacity duration-75 hover:opacity-80"
         >
           <span className="text-sm opacity-40">/</span>
           <span>{linkInfo.slug}</span>

--- a/src/components/links/copy-qr.tsx
+++ b/src/components/links/copy-qr.tsx
@@ -59,7 +59,7 @@ const CopyQR = ({ linkInfo }: CopyQRProps) => {
         <DialogTitle>Copy QR Code</DialogTitle>
         <DialogDescription>{linkInfo.description}</DialogDescription>
       </DialogHeader>
-      <div className="my-3 flex flex-col items-center justify-center space-y-3">
+      <div className="my-3 flex flex-col overflow-hidden items-center justify-center space-y-3">
         <div className="rounded-lg border border-neutral-100 p-2 shadow-md dark:border-neutral-800">
           <QRCode
             id="qr-code"
@@ -69,7 +69,7 @@ const CopyQR = ({ linkInfo }: CopyQRProps) => {
             viewBox={`0 0 128 128`}
           />
         </div>
-        <p className="font-mono font-medium">{`/${linkInfo.slug}`}</p>
+        <p className="font-mono font-medium w-full block truncate">{`/${linkInfo.slug}`}</p>
       </div>
       <DialogFooter>
         <DropdownMenu>

--- a/src/components/links/edit-link.tsx
+++ b/src/components/links/edit-link.tsx
@@ -95,9 +95,9 @@ const EditLink = (props: EditLinkProps) => {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{props.trigger}</DialogTrigger>
       <DialogContent>
-        <DialogHeader>
+        <DialogHeader className="overflow-hidden">
           <DialogTitle>Edit link</DialogTitle>
-          <DialogDescription className="truncate">
+          <DialogDescription className="block truncate">
             /{props.link.slug}
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
Before:
/dashboard
![Screenshot from 2024-04-13 00-02-42](https://github.com/pheralb/slug/assets/145725758/e1d75535-c148-439b-b572-2da03e0ed260)

Modal de Editar
![Screenshot from 2024-04-12 23-56-52](https://github.com/pheralb/slug/assets/145725758/91f02a31-cbc5-47dd-a815-80baec6dca83)

Copy Qr
![Screenshot from 2024-04-13 00-08-40](https://github.com/pheralb/slug/assets/145725758/d9984a00-8d35-441a-83c6-aa05ce4f7718)

After
/dashboard
![Screenshot from 2024-04-13 00-02-55](https://github.com/pheralb/slug/assets/145725758/f491a7c1-d468-4c92-8960-aad21e2a470e)

Modal de Editar
![Screenshot from 2024-04-13 00-03-08](https://github.com/pheralb/slug/assets/145725758/38e9a1bd-0bc6-44d3-a913-216d54bd438e)

Copy Qr
![Screenshot from 2024-04-13 00-08-49](https://github.com/pheralb/slug/assets/145725758/b0531f94-88ce-4309-a5f1-97fb20bec12c)
